### PR TITLE
Update embedded image SDK version

### DIFF
--- a/cmake/aacsimage.cmake
+++ b/cmake/aacsimage.cmake
@@ -1,6 +1,6 @@
 include(ExternalProject)
 set(PACKAGE_NAME_CONTENT_SAFETY_IMAGE "azure.ai.contentsafety.extension.embedded.image")
-set(PACKAGE_VERSION_CONTENT_SAFETY_IMAGE "1.0.1-beta.2")
+set(PACKAGE_VERSION_CONTENT_SAFETY_IMAGE "1.0.1-beta.4")
 set(CONTENT_SAFETY_IMAGE_PROJECT "extern_aacsimage")
 
 SET(AACS_IMG_LIB_FOLDER "Release")


### PR DESCRIPTION
The embedded image SDK version was outdated (1.0.1-beta.2) while customer models are being signed for SDK version 1.0.1-beta.4. This causes "License text is invalid" errors even when the license text is correct.

This fix updates the image SDK version to match the text SDK version (1.0.1-beta.4).

Fixes license validation issue reported by Lenovo.